### PR TITLE
Redirections now work as intended

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -61,7 +61,6 @@ server
     # You can have multiple location blocks
     location /profile {
         # return to another location. This is handled by sending a 3XX response
-        # ! We kind of handle this
         return /;
         limit_except GET POST DELETE PUT HEAD;
     }

--- a/example.conf
+++ b/example.conf
@@ -46,11 +46,11 @@ server
 
         # Optional and the default is false
         # If this is true and the client requests a directory then we should display the contents of the directory
+        # If an index file is specified and it is found then this rule will be ignored
         autoindex true;
 
         # If the client requests to view a directory then show them this file instead
-        # If autoindex is true then this file is ignored
-        # index index.html;
+        index index.html;
 
         # Execute file with CGI if it has one of these extensions
         # This is optional, if it is not specified then we just serve the file like any other resource

--- a/src/requests/Request.cpp
+++ b/src/requests/Request.cpp
@@ -413,12 +413,12 @@ const Resource Request::getResourceFromConfig(const std::map<std::string, Route>
     if (isFile(resourcePath))
         return Resource(EXISTING_FILE, _requestedURL, resourcePath, routeOptions);
 
-    if (isDir(resourcePath) && routeOptions.autoIndex == true)
-        return Resource(DIRECTORY, _requestedURL, resourcePath, routeOptions);
-
     const std::string &indexFile = sanitizeURL(resourcePath + "/" + routeOptions.indexFile);
     if (isDir(resourcePath) && isFile(indexFile))
         return Resource(EXISTING_FILE, _requestedURL, indexFile, routeOptions);
+
+    if (isDir(resourcePath) && routeOptions.autoIndex == true)
+        return Resource(DIRECTORY, _requestedURL, resourcePath, routeOptions);
 
     if (isDir(resourcePath) && !isFile(indexFile))
         return Resource(NOT_FOUND, _requestedURL, indexFile, routeOptions);

--- a/src/requests/Request.cpp
+++ b/src/requests/Request.cpp
@@ -395,9 +395,14 @@ const Resource Request::getResourceFromConfig(const std::map<std::string, Route>
     if (routeOptions.methodsAllowed.count(_httpMethod) == 0)
         return Resource(FORBIDDEN_METHOD, _requestedURL);
     if (routeOptions.redirectTo.length() > 0)
-        return Resource(REDIRECTION, _requestedURL, routeOptions.redirectTo, routeOptions);
-    if (routeOptions.serveDir.length() == 0)
-        return Resource(NOT_FOUND, _requestedURL, _requestedURL, routeOptions);
+    {
+        std::string resourcePath(_requestedURL);
+        resourcePath.erase(0, routeIt->first.length());
+        resourcePath.insert(resourcePath.begin(), routeOptions.redirectTo.begin(),
+                            routeOptions.redirectTo.end());
+        resourcePath = sanitizeURL(resourcePath);
+        return Resource(REDIRECTION, _requestedURL, resourcePath, routeOptions);
+    }
 
     const std::string &resourcePath =
         formPathToResource(routeOptions.serveDir, _requestedURL, routeIt->first);


### PR DESCRIPTION
Redirects now provide the correct path to the requested resource and now the index file in config has priority over the autoindex rule

Closes #51 