### PR TITLE
NO_MATCH is returned if a resource can't be created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ assets/inception
 assets/web
 cgi_tester
 posts/
+assets/upload/cgi-bin/files
+assets/upload/files

--- a/example.conf
+++ b/example.conf
@@ -51,7 +51,6 @@ server
 
         # Execute file with CGI if it has one of these extensions
         # This is optional, if it is not specified then we just serve the file like any other resource
-        # ! We dont handle this yet
         cgi_extensions .php .py;
     }
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -177,4 +177,20 @@ bool isDir(const std::string &path);
  */
 std::string headerToEnv(const std::string &header);
 
+/**
+ * @brief Get the directory component from a pathname
+ *
+ * @param path Full path to a file
+ * @return std::string Directory component of a path
+ */
+std::string dirName(const std::string &path);
+
+/**
+ * @brief Get the file component from a pathname
+ *
+ * @param path Full path to a file
+ * @return std::string File component of a path
+ */
+std::string baseName(const std::string &path);
+
 #endif

--- a/src/config/ServerBlock.cpp
+++ b/src/config/ServerBlock.cpp
@@ -11,6 +11,7 @@
 #include "config/ServerBlock.hpp"
 #include "enums/conversions.hpp"
 #include "utils.hpp"
+#include <algorithm>
 #include <limits>
 #include <sstream>
 

--- a/src/requests/RequestParser.cpp
+++ b/src/requests/RequestParser.cpp
@@ -436,7 +436,11 @@ Resource RequestParser::generateResource(const std::vector<ServerBlock *> &confi
 
     const std::string &trimmedRequestURL = trimQuery(_requestedURL);
     if (!exists(resourcePath))
-        return Resource(NOT_FOUND, trimmedRequestURL, resourcePath, configPair);
+    {
+        if (isDir(dirName(resourcePath)))
+            return Resource(NOT_FOUND, trimmedRequestURL, resourcePath, configPair);
+        return Resource(NO_MATCH, trimmedRequestURL, resourcePath, configPair);
+    }
 
     if (isFile(resourcePath))
         return Resource(EXISTING_FILE, trimmedRequestURL, resourcePath, configPair);
@@ -452,7 +456,11 @@ Resource RequestParser::generateResource(const std::vector<ServerBlock *> &confi
 
         if (isDir(resourcePath) && !isFile(indexFile))
             return Resource(NOT_FOUND, trimmedRequestURL, indexFile, configPair);
-        return Resource(NOT_FOUND, trimmedRequestURL, resourcePath, configPair);
+
+        if (isDir(dirName(resourcePath)))
+            return Resource(NOT_FOUND, trimmedRequestURL, resourcePath, configPair);
+
+        return Resource(NO_MATCH, trimmedRequestURL, resourcePath, configPair);
     }
     return Resource(DIRECTORY, trimmedRequestURL, resourcePath, configPair);
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -150,3 +150,27 @@ std::string headerToEnv(const std::string &header)
     std::replace(cgiEnv.begin(), cgiEnv.end(), '-', '_');
     return cgiEnv;
 }
+
+std::string dirName(const std::string &path)
+{
+    if (path.empty())
+        return ".";
+    if (path == "/")
+        return "/";
+    const size_t lastSlash = path.find_last_of("/");
+    if (lastSlash == std::string::npos)
+        return ".";
+    return path.substr(0, lastSlash);
+}
+
+std::string baseName(const std::string &path)
+{
+    if (path.empty())
+        return ".";
+    if (path == "/")
+        return "/";
+    const size_t lastSlash = path.find_last_of("/");
+    if (lastSlash == std::string::npos)
+        return path;
+    return path.substr(lastSlash + 1);
+}


### PR DESCRIPTION
I also reimplmented `basename()` and `dirname()` from the C stdlib