### PR TITLE
Query string URL is not being decoded anymore

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -51,7 +51,6 @@ server
 
         # Execute file with CGI if it has one of these extensions
         # This is optional, if it is not specified then we just serve the file like any other resource
-        # ! We dont handle this yet
         cgi_extensions .php .py;
     }
 

--- a/src/config/ServerBlock.cpp
+++ b/src/config/ServerBlock.cpp
@@ -11,6 +11,7 @@
 #include "config/ServerBlock.hpp"
 #include "enums/conversions.hpp"
 #include "utils.hpp"
+#include <algorithm>
 #include <limits>
 #include <sstream>
 

--- a/src/requests/RequestParser.cpp
+++ b/src/requests/RequestParser.cpp
@@ -305,6 +305,12 @@ const std::map<std::string, Route>::const_iterator RequestParser::getRequestedRo
         if (_requestedURL.length() >= it->first.length() &&
             std::equal(it->first.begin(), it->first.end(), _requestedURL.begin()))
         {
+            if (_requestedURL.length() > it->first.length())
+            {
+                const char nextChar = _requestedURL[it->first.length()];
+                if (nextChar != '/' && nextChar != '?')
+                    continue;
+            }
             if (routeIt == routes.end())
                 routeIt = it;
             else if (it->first.length() > routeIt->first.length())

--- a/src/requests/RequestParser.cpp
+++ b/src/requests/RequestParser.cpp
@@ -305,12 +305,6 @@ const std::map<std::string, Route>::const_iterator RequestParser::getRequestedRo
         if (_requestedURL.length() >= it->first.length() &&
             std::equal(it->first.begin(), it->first.end(), _requestedURL.begin()))
         {
-            if (_requestedURL.length() > it->first.length())
-            {
-                const char nextChar = _requestedURL[it->first.length()];
-                if (nextChar != '/' && nextChar != '?')
-                    continue;
-            }
             if (routeIt == routes.end())
                 routeIt = it;
             else if (it->first.length() > routeIt->first.length())

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -42,16 +42,26 @@ unsigned int getHex(const std::string &str)
 
 std::string sanitizeURL(const std::string &url)
 {
-    std::string sanitizedUrl(url);
+    std::string sanitizedURL;
+    std::string queryStr;
+    const size_t queryPos = url.find("?");
+    if (queryPos != std::string::npos)
+    {
+        if (queryPos > 0)
+            sanitizedURL = url.substr(0, queryPos);
+        queryStr = url.substr(queryPos);
+    }
+    else
+        sanitizedURL = url;
 
     // Remove duplicate slashes
-    removeDuplicateChar(sanitizedUrl, '/');
+    removeDuplicateChar(sanitizedURL, '/');
 
     // Replace '+' with ' '
-    std::replace(sanitizedUrl.begin(), sanitizedUrl.end(), '+', ' ');
+    std::replace(sanitizedURL.begin(), sanitizedURL.end(), '+', ' ');
 
     // Decode % hexadecimal characters
-    for (std::string::iterator it = sanitizedUrl.begin(); it < sanitizedUrl.end() - 2; it++)
+    for (std::string::iterator it = sanitizedURL.begin(); it < sanitizedURL.end() - 2; it++)
     {
         if (*it != '%')
             continue;
@@ -64,9 +74,9 @@ std::string sanitizeURL(const std::string &url)
         *it = getHex(hexStr);
 
         // Erase the next two characters and get a valid iterator
-        it = sanitizedUrl.erase(it + 1, it + 3) - 1;
+        it = sanitizedURL.erase(it + 1, it + 3) - 1;
     }
-    return sanitizedUrl;
+    return sanitizedURL + queryStr;
 }
 
 const std::string getLine(const std::string &filename, const unsigned int lineNum)


### PR DESCRIPTION
The `sanitizeURL()` now skips processing of the query string altogether